### PR TITLE
#refac - 엔티티 equals(), hashcode() 비교 로직에 getter 적용

### DIFF
--- a/src/main/java/com/fastcampus/boardprojfc/domain/Article.java
+++ b/src/main/java/com/fastcampus/boardprojfc/domain/Article.java
@@ -32,10 +32,9 @@ public class Article extends AuditingFields {
     @Setter
     @Column(nullable = false)
     private String title; // 제목
-
     @Setter
     @Column(nullable = false, length = 10000)
-    private String content; // 내용
+    private String content; // 본문
 
     @Setter
     private String hashtag; // 해시태그
@@ -63,13 +62,13 @@ public class Article extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Article article = (Article) o;
-        return id.equals(article.id);
+        if (!(o instanceof Article that)) return false;
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
+
 }

--- a/src/main/java/com/fastcampus/boardprojfc/domain/ArticleComment.java
+++ b/src/main/java/com/fastcampus/boardprojfc/domain/ArticleComment.java
@@ -16,18 +16,18 @@ import java.util.Objects;
 })
 @Entity
 public class ArticleComment extends AuditingFields {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Setter
     @ManyToOne(optional = false)
-    private Article article; // 게시글 (id)
-
+    private Article article; // 게시글 (ID)
     @Setter
     @ManyToOne(optional = false)
     @JoinColumn(name = "userId")
-    private UserAccount userAccount;
+    private UserAccount userAccount; // 유저 정보 (ID)
 
     @Setter
     @Column(nullable = false, length = 500)
@@ -50,13 +50,13 @@ public class ArticleComment extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ArticleComment that = (ArticleComment) o;
-        return id.equals(that.id);
+        if (!(o instanceof ArticleComment that)) return false;
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
+
 }

--- a/src/main/java/com/fastcampus/boardprojfc/domain/UserAccount.java
+++ b/src/main/java/com/fastcampus/boardprojfc/domain/UserAccount.java
@@ -20,14 +20,22 @@ public class UserAccount extends AuditingFields {
     @Column(length = 50)
     private String userId;
 
-    @Setter @Column(nullable = false) private String userPassword;
+    @Setter
+    @Column(nullable = false)
+    private String userPassword;
 
-    @Setter @Column(length = 100) private String email;
-    @Setter @Column(length = 100) private String nickname;
-    @Setter private String memo;
+    @Setter
+    @Column(length = 100)
+    private String email;
+    @Setter
+    @Column(length = 100)
+    private String nickname;
+    @Setter
+    private String memo;
 
 
-    protected UserAccount() {}
+    protected UserAccount() {
+    }
 
     private UserAccount(String userId, String userPassword, String email, String nickname, String memo) {
         this.userId = userId;
@@ -44,13 +52,13 @@ public class UserAccount extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount userAccount)) return false;
-        return userId != null && userId.equals(userAccount.userId);
+        if (!(o instanceof UserAccount that)) return false;
+        return this.getUserId() != null && this.getUserId().equals(that.getUserId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 
 }


### PR DESCRIPTION
여기서 필드에 직접 접근하면,
하이버네이트가 지연 로딩하려고 만든 프록시 객체를 다룰 때
필드 값이 `null`일 수 있음
그러면 제대로 비교 로직을 수행할 수 없기 떄문에
getter를 이용함.
이것으로 프록시 객체를 타더라도 제대로 값을 읽어올 수 있음